### PR TITLE
Adding privacy policy to documentation website

### DIFF
--- a/Documentation/docfx.json
+++ b/Documentation/docfx.json
@@ -31,6 +31,12 @@
                 ]
             },
             {
+                "files": [
+                    "docs/toc.yml",
+                    "docs/**.md"
+                ]
+            },
+            {
                 "src": "api",
                 "files": [
                     "*.yml"

--- a/Documentation/docs/privacy.md
+++ b/Documentation/docs/privacy.md
@@ -1,0 +1,67 @@
+---
+title: Privacy Policy
+---
+
+# Privacy Policy
+
+Last updated: January 13, 2026
+
+## 1. Introduction
+
+This Privacy Policy explains how **Meteor Studio** (“we”, “our”, or “us”) handles information when you use **Planetary Parfait** (the “Application”).
+We value your privacy and are committed to being transparent about our data practices.
+
+## 2. Information We Collect
+
+We do **not** knowingly collect, store, or process personal data such as names, email addresses, physical addresses, or precise location information.
+
+The Application uses **Unity Analytics**, a service provided by Unity Technologies, to collect **anonymous usage data**. This data helps us understand how players interact with the Application and improve performance, stability, and gameplay.
+
+The data collected may include:
+- Game events and interactions
+- Session duration and frequency
+- Device and system information (such as operating system and hardware type)
+- Crash and performance diagnostics
+
+This data is aggregated and anonymized and cannot be used by us to identify individual users.
+
+## 3. How We Use the Information
+
+The anonymous analytics data is used solely to:
+- Monitor application performance and stability
+- Identify bugs and crashes
+- Improve gameplay and user experience
+
+We do not use this data for advertising, marketing, or user profiling.
+
+## 4. Third-Party Services
+
+The Application uses **Unity Analytics**, which may collect and process data in accordance with Unity’s own Privacy Policy.
+
+You can learn more about Unity’s data practices here:
+
+https://unity.com/legal/game-player-and-app-user-privacy-policy 
+
+We do not share analytics data with any other third parties.
+
+## 5. Data Retention
+
+Any analytics data collected is retained by Unity for the period defined by their policies. We do not maintain our own database of user analytics data.
+
+## 6. Children’s Privacy
+
+The Application is not directed toward children under the age of 13. We do not knowingly collect personal information from children.
+
+## 7. Your Rights
+
+Because we do not collect or store personal data, we cannot identify or respond to requests to access, modify, or delete individual user data.
+If you have concerns about data collected by Unity Analytics, please review Unity’s Privacy Policy or contact Unity Technologies directly.
+
+## 8. Changes to This Policy
+
+We may update this Privacy Policy from time to time. Any changes will be reflected by updating the “Last updated” date above.
+
+## 9. Contact
+
+If you have any questions about this Privacy Policy, you may contact us at:
+planetaryparfait@gmail.com

--- a/Documentation/docs/toc.yml
+++ b/Documentation/docs/toc.yml
@@ -1,0 +1,2 @@
+- name: Privacy Policy
+  href: privacy.md

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -1,2 +1,4 @@
 - name: API Reference
   href: api/
+- name: Docs
+  href: docs/


### PR DESCRIPTION
Added a privacy policy page to the documentation site. Github actions will build and deploy the site once merged. To test locally:  

Download DocFX via .NET: `dotnet tool install --global docfx --version 2.61.0`

Build and run site (from project root):
```
docfx Documentation/docfx.json
docfx serve _site
```