### PR TITLE
Various fixes

### DIFF
--- a/Assets/Scripts/TerrainEngine/TerrainColorTextureProvider.cs
+++ b/Assets/Scripts/TerrainEngine/TerrainColorTextureProvider.cs
@@ -22,6 +22,7 @@ namespace TerrainEngine
     
             resolution = new Vector2Int(200, 200);
             texture = new RenderTexture(200, 200, 16);
+            texture.filterMode = FilterMode.Point;
             quads = new List<GameObject>();
             cam = gameObject.AddComponent<Camera>();
             cam.transform.position = Vector3.zero;
@@ -124,6 +125,7 @@ namespace TerrainEngine
             if (resolution.x != width || resolution.y != height) {
                 resolution = new Vector2Int(width, height);
                 texture = new RenderTexture(width, height, 16);
+                texture.filterMode = FilterMode.Point;
                 cam.targetTexture = texture;
             }
         }

--- a/Assets/Scripts/TerrainEngine/Tools/PerPixelDataReader.cs
+++ b/Assets/Scripts/TerrainEngine/Tools/PerPixelDataReader.cs
@@ -240,7 +240,7 @@ namespace TerrainEngine.Tools
                     {
                         if (index <= (heightTexture.width * heightTexture.height))
                         {
-                            byteOutput += byteDataNames[i] + ": " + byteArrays[i][index] + " " +
+                            byteOutput += byteDataNames[i] + ": " + byteArrays[i][index*2] + " " +
                                           byteDataUnits[i] + "\n";
                         }
                         else

--- a/Assets/Scripts/UserInterface/Login.cs
+++ b/Assets/Scripts/UserInterface/Login.cs
@@ -17,7 +17,7 @@ namespace UserInterface
         public static LoginDelegate FailedLogin { get; private set; }
         public static MenuDelegate TryLogin { get; private set; }
 
-        public static bool LoggedIn = false;
+        public static bool LoggedIn;
         
         [Header("Login GameObjects")]
         public TMP_InputField usernameField;
@@ -40,7 +40,10 @@ namespace UserInterface
         new void Start()
         {
             base.Start();
-            username = ""; // doesn't save any data after closing app
+            // doesn't save any data after closing app
+            username = "";
+            password = "";
+            LoggedIn = false;
         }
 
         private void Update()

--- a/Assets/Scripts/UserInterface/TerrainMenu.cs
+++ b/Assets/Scripts/UserInterface/TerrainMenu.cs
@@ -66,8 +66,6 @@ namespace UserInterface
                 buttonClick.Play();
                 ToggleMenu(false);
                 MainMenu.OpenMenu(true);
-                Login.username = "";
-                Login.password = "";
             });
             
             backToGameButton.onClick.AddListener(delegate
@@ -84,6 +82,8 @@ namespace UserInterface
                 buttonClick.Play();
                 ToggleMenu(false);
                 MainMenu.OpenMenu(true);
+                Login.username = "";
+                Login.password = "";
                 Login.LoggedIn = false;
             });
         }
@@ -345,7 +345,7 @@ namespace UserInterface
                 //float heightValue = scene.depthTexture.GetPixel(scene.depthTexture.width/2, scene.depthTexture.height/2).r * SceneMaterializer.singleton.heightMaterial.GetFloat("_scaleFactor");
                 //SceneMaterializer.singleton.tiles.transform.localPosition = new Vector3(0, -heightValue, 0);
 
-                //original scaling is (200, 200, 200) - multiply current scale value by 200 to get approporiate values
+                //original scaling is (200, 100, 200) - multiply current scale value by 100 to get approporiate values
                 SceneMaterializer.singleton.terrain.transform.localScale = new Vector3(
                     SceneMaterializer.singleton.terrain.transform.localScale.x, t * 100,
                     SceneMaterializer.singleton.terrain.transform.localScale.z);
@@ -360,7 +360,7 @@ namespace UserInterface
                 buttonClick.Play();
                 exagSlider.value = 1;
                 SceneMaterializer.singleton.terrain.transform.localScale = new Vector3(
-                    SceneMaterializer.singleton.terrain.transform.localScale.x, 200,
+                    SceneMaterializer.singleton.terrain.transform.localScale.x, 100,
                     SceneMaterializer.singleton.terrain.transform.localScale.z);
                 exagValue.text = "Exaggeration: " + (float)Math.Round(exagSlider.value, 2);
                 InfoPanel.Panel.ChangeExaggeration((float)Math.Round(exagSlider.value, 2));


### PR DESCRIPTION
- Added username and password clear and set LoggedIn to false on start.
- Moved username and password clear from back to main menu button to logout button.
- Fixed terrain scaling being double intended default on reset.
- Fixed index bug that was reading padding from byte data layers as actual data.
- Changed filter mode of terrain textures to point instead of the default bilinear. This makes for better clarity on which pixel is being read when using the per-pixel data reader.
- Changed VR menu canvas component sorting layer to 10 so it properly appears in front of platform glass.